### PR TITLE
identity verification abstraction

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -85,9 +85,9 @@ export class BetterAuthClient {
   }
 
   async createAccount(recoveryHash: string): Promise<void> {
-    const [publicKey, rotationHash] = await this.args.store.key.authentication.initialize()
+    const [identity, publicKey, rotationHash] =
+      await this.args.store.key.authentication.initialize(recoveryHash)
     const device = await this.args.crypto.hasher.sum(publicKey)
-    const identity = await this.args.crypto.hasher.sum(publicKey + rotationHash + recoveryHash)
 
     const nonce = await this.args.crypto.noncer.generate128()
 
@@ -122,7 +122,7 @@ export class BetterAuthClient {
   // happens on the new device
   // send identity by qr code or network from the existing device
   async generateLinkContainer(identity: string): Promise<string> {
-    const [publicKey, rotationHash] = await this.args.store.key.authentication.initialize()
+    const [, publicKey, rotationHash] = await this.args.store.key.authentication.initialize()
     const device = await this.args.crypto.hasher.sum(publicKey)
 
     await this.args.store.identifier.identity.store(identity)
@@ -227,7 +227,7 @@ export class BetterAuthClient {
       throw 'incorrect nonce'
     }
 
-    const [currentKey, nextKeyHash] = await this.args.store.key.access.initialize()
+    const [, currentKey, nextKeyHash] = await this.args.store.key.access.initialize()
     const finishNonce = await this.args.crypto.noncer.generate128()
 
     const finishRequest = new CompleteAuthenticationRequest(
@@ -291,7 +291,7 @@ export class BetterAuthClient {
   }
 
   async recoverAccount(identity: string, recoveryKey: ISigningKey): Promise<void> {
-    const [current, rotationHash] = await this.args.store.key.authentication.initialize()
+    const [, current, rotationHash] = await this.args.store.key.authentication.initialize()
     const device = await this.args.crypto.hasher.sum(current)
     const nonce = await this.args.crypto.noncer.generate128()
 

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,5 +1,6 @@
 import {
   IHasher,
+  IIdentityVerifier,
   INoncer,
   IServerAuthenticationKeyStore,
   IServerAuthenticationNonceStore,
@@ -44,6 +45,7 @@ export class BetterAuthServer {
         verifier: IVerifier
       }
       encoding: {
+        identityVerifier: IIdentityVerifier
         timestamper: ITimestamper
         tokenizer: ITokenizer
       }
@@ -83,15 +85,12 @@ export class BetterAuthServer {
 
     const identity = request.payload.request.authentication.identity
 
-    const identityHash = await this.args.crypto.hasher.sum(
-      request.payload.request.authentication.publicKey +
-        request.payload.request.authentication.rotationHash +
-        request.payload.request.authentication.recoveryHash
+    await this.args.encoding.identityVerifier.verify(
+      identity,
+      request.payload.request.authentication.publicKey,
+      request.payload.request.authentication.rotationHash,
+      request.payload.request.authentication.recoveryHash
     )
-
-    if (identityHash !== identity) {
-      throw 'malformed identity'
-    }
 
     const deviceHash = await this.args.crypto.hasher.sum(
       request.payload.request.authentication.publicKey

--- a/src/interfaces/encoding.ts
+++ b/src/interfaces/encoding.ts
@@ -8,3 +8,12 @@ export interface ITokenizer {
   encode(object: string): Promise<string>
   decode(rawToken: string): Promise<string>
 }
+
+export interface IIdentityVerifier {
+  verify(
+    identity: string,
+    publicKey: string,
+    rotationHash: string,
+    extraData?: string
+  ): Promise<void>
+}

--- a/src/interfaces/storage.ts
+++ b/src/interfaces/storage.ts
@@ -11,13 +11,13 @@ export interface IClientValueStore {
 }
 
 export interface IClientRotatingKeyStore {
-  // returns: [current public key, next public key hash]
-  initialize(): Promise<[string, string]>
+  // returns: [identity, publicKey, rotationHash]
+  initialize(extraData?: string): Promise<[string, string, string]>
 
   // throw an exception if:
   // - no keys exist
   //
-  // returns: [current public key, next public key hash]
+  // returns: [publicKey, rotationHash]
   rotate(): Promise<[string, string]>
 
   // returns: effectively, a handle to a signing key
@@ -49,7 +49,7 @@ export interface IServerAuthenticationKeyStore {
   register(
     identity: string,
     device: string,
-    current: string,
+    publicKey: string,
     rotationHash: string,
     existingIdentity: boolean
   ): Promise<void>

--- a/src/tests/api.test.ts
+++ b/src/tests/api.test.ts
@@ -11,6 +11,7 @@ import {
   ClientRotatingKeyStore,
   ClientValueStore,
   Hasher,
+  IdentityVerifier,
   Noncer,
   Rfc3339Nano,
   Secp256r1,
@@ -220,6 +221,7 @@ async function createServer(args: {
       verifier: eccVerifier,
     },
     encoding: {
+      identityVerifier: new IdentityVerifier(),
       timestamper: new Rfc3339Nano(),
       tokenizer: new Tokenizer(),
     },

--- a/src/tests/implementation/encoding/identity.ts
+++ b/src/tests/implementation/encoding/identity.ts
@@ -1,0 +1,27 @@
+import { IHasher, IIdentityVerifier } from '../../../interfaces'
+import { Hasher } from '../crypto'
+
+export class IdentityVerifier implements IIdentityVerifier {
+  hasher: IHasher
+
+  constructor() {
+    this.hasher = new Hasher()
+  }
+
+  async verify(
+    identity: string,
+    publicKey: string,
+    rotationHash: string,
+    extraData?: string
+  ): Promise<void> {
+    let suffix = ''
+    if (typeof extraData !== 'undefined') {
+      suffix = extraData
+    }
+
+    const identityHash = await this.hasher.sum(publicKey + rotationHash + suffix)
+    if (identityHash !== identity) {
+      throw 'could not verify identity'
+    }
+  }
+}

--- a/src/tests/implementation/encoding/index.ts
+++ b/src/tests/implementation/encoding/index.ts
@@ -1,3 +1,4 @@
 export * from './base64'
 export * from './tokenizer'
 export * from './timestamper'
+export * from './identity'


### PR DESCRIPTION
the purpose of this PR is to abstract the verification of the identity that is generated on the client. this permits backing with a DKMS like KERI, where strong verifiable identifiers are derived from key and other data. to acommodate this, i modified the rotating key store interface to return an account id and leave it to the implementer to coordinate between the client side keystore and the server side verifier.

the sample implementation is kind of a lite version of KERI. we hash the key/hash to establish an identifier, and we mix the recoveryHash into that hash as well.